### PR TITLE
Fixing regexes to make 'todo' works

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --profile 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,10 +4,3 @@ FileName:
 
 LineLength:
   Max: 190
-
-Style/IndentArray:
-  EnforcedStyle: consistent
-  SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,10 @@ FileName:
 
 LineLength:
   Max: 190
+
+Style/IndentArray:
+  EnforcedStyle: consistent
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,4 @@ FileName:
     - lib/lita-jira.rb
 
 LineLength:
-  Max: 130
+  Max: 190

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
   - 2.1
-script: bundle exec rake
-before_install:
-  - gem update --system
 services:
   - redis-server
+sudo: false
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3.0
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.1
+  - 2.2
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
+  - 2.3
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
+  - 2.2.2
 services:
   - redis-server
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning] and [Keep A Changelog].
 
 ## [0.7.2] - 2015-12-01
 ### Fixed
+- Updated Simplecov invocation to newer style
 - Adjusted ambient issue detection to avoid triggering on URL-like strings
 
 [Unreleased]: https://github.com/esigler/lita-jira/compare/v0.7.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning] and [Keep A Changelog].
+
+## [Unreleased]
+
+## [0.7.2] - 2015-12-01
+### Fixed
+- Adjusted ambient issue detection to avoid triggering on URL-like strings
+
+[Unreleased]: https://github.com/esigler/lita-jira/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/esigler/lita-jira/compare/v0.7.1...v0.7.2
+[Semantic Versioning]: http://semver.org/
+[Keep A Changelog]: http://keepachangelog.com/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,7 @@ Pull requests are awesome!  Pull requests with tests are even more awesome!
 3. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, it needs a test!
 4. Make the test pass.
 5. Push to your fork and submit a pull request.
+
+## Reminders
+
+* Be sure to add yourself to the Gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'jira-ruby', require: 'jira'
-gem 'pry-byebug'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'jira-ruby', require: 'jira'
+gem 'pry-byebug'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ todo <project> "<subject>" ["<summary>"] - Creates an issue in <project> with <s
 jira <issue>                             - Shows a short summary <issue>
 jira details <issue>                     - Shows all details about <issue>
 jira comment on <issue> <comment text>   - Adds <comment text> to <issue>
+jira myissues                            - Displays a list of issues assigned to identified user
 ```
 
 ### Misc

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 config.handlers.jira.context  = '' # If your instance is in a /subdirectory, put that here
 ```
 
+### Optional attributes
+* `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
+```
+config.handlers.jira.ambient = true
+```
+
 ## Usage
 
 ### Shortcuts

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 * `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
 * `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
-* `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Accepts both user names and IDs. Default: `[]`
+* `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Accepts user names, mention names, and IDs. Default: `[]`
 * `rooms` (array) - Limit ambient JIRA issue detection to a certain list of rooms. If unspecified, the bot will respond to detected issues in all rooms.
 
 ``` ruby

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ jira forget                   - Remove your chat user / email association
 jira whoami                   - Show your chat user / email association
 ```
 
+## CHANGELOG
+
+[CHANGELOG](https://github.com/esigler/lita-jira/releases)
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
 * `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Accepts user names, mention names, and IDs. Default: `[]`
 * `rooms` (array) - Limit ambient JIRA issue detection to a certain list of rooms. If unspecified, the bot will respond to detected issues in all rooms.
+* `use_ssl` (boolean) - When set to `true`, an SSL connection will be used to JIRA. Set to `false` if you run JIRA over plain http.
 
 ``` ruby
 config.handlers.jira.context = '/myjira'
@@ -40,6 +41,7 @@ config.handlers.jira.format = 'one-line'
 config.handlers.jira.ambient = true
 config.handlers.jira.ignore = ['Jira', 'Github', 'U1234']
 config.handlers.jira.rooms = ['devtools', 'engineering']
+config.handlers.jira.use_ssl = false
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 
 ### Optional attributes
 * `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
-* `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
 * `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
-* `ignore` (array) - Prevent JIRA issue lookups from certain users with this parameter. Default: `[]`
-* `rooms` (array) - Specify a list of rooms to which responses to detected ambient JIRA issues should be limited. By default, the bot will respond to all rooms.
+* `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
+* `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Default: `[]`
+* `rooms` (array) - Limit ambient JIRA issue detection to a certain list of rooms. If unspecified, the bot will respond to detected issues in all rooms.
 
 ``` ruby
 config.handlers.jira.context = '/myjira'

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 
 ``` ruby
 config.handlers.jira.context = '/myjira'
-config.handlers.jira.ambient = true
 config.handlers.jira.format = 'one-line'
+config.handlers.jira.ambient = true
 config.handlers.jira.ignore = ['Jira', 'Github']
 config.handlers.jira.rooms = ['devtools', 'engineering']
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gem "lita-jira"
 
 Add the following variables to your lita config file:
 
-```
+``` ruby
 config.handlers.jira.username = 'your_jira_username'
 config.handlers.jira.password = 'a_password'
 config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
@@ -31,10 +31,15 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 * `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
 * `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
-```
+* `ignore` (array) - Prevent JIRA issue lookups from certain users with this parameter. Default: `[]`
+* `rooms` (array) - Specify a list of rooms to which responses to detected ambient JIRA issues should be limited. By default, the bot will respond to all rooms.
+
+``` ruby
 config.handlers.jira.context = '/myjira'
 config.handlers.jira.ambient = true
 config.handlers.jira.format = 'one-line'
+config.handlers.jira.ignore = ['Jira', 'Github']
+config.handlers.jira.rooms = ['devtools', 'engineering']
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,13 +25,16 @@ Add the following variables to your lita config file:
 config.handlers.jira.username = 'your_jira_username'
 config.handlers.jira.password = 'a_password'
 config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
-config.handlers.jira.context  = '' # If your instance is in a /subdirectory, put that here
 ```
 
 ### Optional attributes
+* `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
+* `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
 ```
+config.handlers.jira.context = '/myjira'
 config.handlers.jira.ambient = true
+config.handlers.jira.format = 'one-line'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 * `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
 * `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
-* `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Default: `[]`
+* `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Accepts both user names and IDs. Default: `[]`
 * `rooms` (array) - Limit ambient JIRA issue detection to a certain list of rooms. If unspecified, the bot will respond to detected issues in all rooms.
 
 ``` ruby
 config.handlers.jira.context = '/myjira'
 config.handlers.jira.format = 'one-line'
 config.handlers.jira.ambient = true
-config.handlers.jira.ignore = ['Jira', 'Github']
+config.handlers.jira.ignore = ['Jira', 'Github', 'U1234']
 config.handlers.jira.rooms = ['devtools', 'engineering']
 ```
 

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -23,18 +23,13 @@ module JiraHelper
         log.error('JIRA HTTPError')
         nil
     end
-
-    def format_issue(issue)
+def format_issue(issue)
       t(config.format == 'one-line' ? 'issue.oneline' : 'issue.details',
         key: issue.key,
         summary: issue.summary,
         status: issue.status.name,
         assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
-        fixVersion: optional_issue_property('none') do
-          v = issue.fixVersions
-          raise if v == []
-          v
-        end,
+        fixVersion: optional_issue_property('none') { issue.fixVersions.first['name'] },
         priority: optional_issue_property('none') { issue.priority.name },
         url: format_issue_link(issue.key))
     end

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -25,12 +25,18 @@ module JiraHelper
     end
 
     def format_issue(issue)
-      t('issue.details',
+      t(config.format == 'one-line' ? 'issue.oneline' : 'issue.details',
         key: issue.key,
         summary: issue.summary,
+        status: issue.status.name,
         assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
+        fixVersion: optional_issue_property('none') do
+          v = issue.fixVersions
+          raise if v.empty?
+          v
+        end,
         priority: optional_issue_property('none') { issue.priority.name },
-        status: issue.status.name)
+        url: format_issue_link(issue.key))
     end
 
     # Enumerate issues returned from JQL query and format for response
@@ -40,6 +46,10 @@ module JiraHelper
     def format_issues(issues)
       results = [t('myissues.info')]
       results.concat(issues.map { |issue| format_issue(issue) })
+    end
+
+    def format_issue_link(key)
+      "#{config.site}/browse/#{key}"
     end
 
     def create_issue(project, subject, summary)

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -2,15 +2,12 @@
 module JiraHelper
   # Issues
   module Issue
-    # NOTE: Prefer this syntax here as it's cleaner
-    # rubocop:disable Style/RescueEnsureAlignment
     def fetch_issue(key, expected = true)
       client.Issue.find(key)
-      rescue
-        log.error('JIRA HTTPError') if expected
-        nil
+    rescue
+      log.error('JIRA HTTPError') if expected
+      nil
     end
-    # rubocop:enable Style/RescueEnsureAlignment
 
     # Leverage the jira-ruby Issue.jql search feature
     #
@@ -20,15 +17,12 @@ module JiraHelper
       client.Issue.jql(jql)
     end
 
-    # NOTE: Prefer this syntax here as it's cleaner
-    # rubocop:disable Style/RescueEnsureAlignment
     def fetch_project(key)
       client.Project.find(key)
-      rescue
-        log.error('JIRA HTTPError')
-        nil
+    rescue
+      log.error('JIRA HTTPError')
+      nil
     end
-    # rubocop:enable Style/RescueEnsureAlignment
 
     # NOTE: Not breaking this function out just yet.
     # rubocop:disable Metrics/AbcSize

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -2,11 +2,11 @@
 module JiraHelper
   # Issues
   module Issue
-    def fetch_issue(key, expected=true)
+    def fetch_issue(key, expected = true)
       client.Issue.find(key)
-      rescue
-        log.error('JIRA HTTPError') if expected
-        nil
+    rescue
+      log.error('JIRA HTTPError') if expected
+      nil
     end
 
     # Leverage the jira-ruby Issue.jql search feature
@@ -19,11 +19,14 @@ module JiraHelper
 
     def fetch_project(key)
       client.Project.find(key)
-      rescue
-        log.error('JIRA HTTPError')
-        nil
+    rescue
+      log.error('JIRA HTTPError')
+      nil
     end
-def format_issue(issue)
+
+    # NOTE: Not breaking this function out just yet.
+    # rubocop:disable Metrics/AbcSize
+    def format_issue(issue)
       t(config.format == 'one-line' ? 'issue.oneline' : 'issue.details',
         key: issue.key,
         summary: issue.summary,
@@ -33,6 +36,7 @@ def format_issue(issue)
         priority: optional_issue_property('none') { issue.priority.name },
         url: format_issue_link(issue.key))
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Enumerate issues returned from JQL query and format for response
     #

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -49,7 +49,7 @@ module JiraHelper
     end
 
     def format_issue_link(key)
-      "#{config.site}/browse/#{key}"
+      "#{config.site}#{config.context}/browse/#{key}"
     end
 
     def create_issue(project, subject, summary)

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -15,9 +15,6 @@ module JiraHelper
     # @return [Type Array] 0-m JIRA Issues returned from query
     def fetch_issues(jql)
       client.Issue.jql(jql)
-    rescue
-      log.error('JIRA HTTPError')
-      []
     end
 
     def fetch_project(key)

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -2,10 +2,10 @@
 module JiraHelper
   # Issues
   module Issue
-    def fetch_issue(key)
+    def fetch_issue(key, expected=true)
       client.Issue.find(key)
       rescue
-        log.error('JIRA HTTPError')
+        log.error('JIRA HTTPError') if expected
         nil
     end
 

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -2,12 +2,15 @@
 module JiraHelper
   # Issues
   module Issue
+    # NOTE: Prefer this syntax here as it's cleaner
+    # rubocop:disable Style/RescueEnsureAlignment
     def fetch_issue(key)
       client.Issue.find(key)
       rescue
         log.error('JIRA HTTPError')
         nil
     end
+    # rubocop:enable Style/RescueEnsureAlignment
 
     # Leverage the jira-ruby Issue.jql search feature
     #
@@ -17,12 +20,15 @@ module JiraHelper
       client.Issue.jql(jql)
     end
 
+    # NOTE: Prefer this syntax here as it's cleaner
+    # rubocop:disable Style/RescueEnsureAlignment
     def fetch_project(key)
       client.Project.find(key)
       rescue
         log.error('JIRA HTTPError')
         nil
     end
+    # rubocop:enable Style/RescueEnsureAlignment
 
     def format_issue(issue)
       t('issue.details',

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -32,7 +32,7 @@ module JiraHelper
         assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
         fixVersion: optional_issue_property('none') do
           v = issue.fixVersions
-          raise if v.empty?
+          raise if v == []
           v
         end,
         priority: optional_issue_property('none') { issue.priority.name },

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -20,8 +20,8 @@ module JiraHelper
       t('issue.details',
         key: issue.key,
         summary: issue.summary,
-        assigned: issue.assignee.displayName,
-        priority: issue.priority.name,
+        assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
+        priority: optional_issue_property('none') { issue.priority.name },
         status: issue.status.name)
     end
 
@@ -34,6 +34,18 @@ module JiraHelper
                            project: { id: project.id } })
       issue.fetch
       issue
+    end
+
+    # Attempt to retrieve optional JIRA issue property value via a provided block.
+    # JIRA properties such as assignee and priority may not exist.
+    # In that case, the fallback will be used.
+    #
+    # @param [Type String] fallback A String value to use if the JIRA property value doesn't exist
+    # @return [Type] fallback or returned value from yield block
+    def optional_issue_property(fallback = '')
+      yield
+    rescue
+      fallback
     end
   end
 end

--- a/lib/jirahelper/misc.rb
+++ b/lib/jirahelper/misc.rb
@@ -9,7 +9,7 @@ module JiraHelper
         site: config.site,
         context_path: config.context,
         auth_type: :basic,
-        use_ssl: config.use_ssl,
+        use_ssl: config.use_ssl
       )
     end
   end

--- a/lib/jirahelper/misc.rb
+++ b/lib/jirahelper/misc.rb
@@ -8,7 +8,8 @@ module JiraHelper
         password: config.password,
         site: config.site,
         context_path: config.context,
-        auth_type: :basic
+        auth_type: :basic,
+        use_ssl: config.use_ssl,
       )
     end
   end

--- a/lib/jirahelper/regex.rb
+++ b/lib/jirahelper/regex.rb
@@ -9,5 +9,6 @@ module JiraHelper
     ISSUE_PATTERN   = /(?<issue>#{PROJECT_PATTERN}-[0-9]{1,5}+)/
     EMAIL_PATTERN   = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i
     AMBIENT_PATTERN = /(\s|^)#{ISSUE_PATTERN}/
+    POINTS_PATTERN  = /(?<points>\d{1,2})/
   end
 end

--- a/lib/jirahelper/regex.rb
+++ b/lib/jirahelper/regex.rb
@@ -8,5 +8,6 @@ module JiraHelper
     PROJECT_PATTERN = /(?<project>[a-zA-Z0-9]{1,10})/
     ISSUE_PATTERN   = /(?<issue>#{PROJECT_PATTERN}-[0-9]{1,5}+)/
     EMAIL_PATTERN   = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i
+    AMBIENT_PATTERN = /\s#{ISSUE_PATTERN}/
   end
 end

--- a/lib/jirahelper/regex.rb
+++ b/lib/jirahelper/regex.rb
@@ -3,8 +3,8 @@ module JiraHelper
   # Regular expressions
   module Regex
     COMMENT_PATTERN = /\"(?<comment>.+)\"/
-    SUBJECT_PATTERN = /\"(?<subject>.+)\"/
-    SUMMARY_PATTERN = /\"(?<summary>.+)\"/
+    SUBJECT_PATTERN = /\"(?<subject>.+?)\"/
+    SUMMARY_PATTERN = /\"(?<summary>.+?)\"/
     PROJECT_PATTERN = /(?<project>[a-zA-Z0-9]{1,10})/
     ISSUE_PATTERN   = /(?<issue>#{PROJECT_PATTERN}-[0-9]{1,5}+)/
     EMAIL_PATTERN   = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i

--- a/lib/jirahelper/regex.rb
+++ b/lib/jirahelper/regex.rb
@@ -8,6 +8,6 @@ module JiraHelper
     PROJECT_PATTERN = /(?<project>[a-zA-Z0-9]{1,10})/
     ISSUE_PATTERN   = /(?<issue>#{PROJECT_PATTERN}-[0-9]{1,5}+)/
     EMAIL_PATTERN   = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i
-    AMBIENT_PATTERN = /\s#{ISSUE_PATTERN}/
+    AMBIENT_PATTERN = /(\s|^)#{ISSUE_PATTERN}/
   end
 end

--- a/lib/lita-jira.rb
+++ b/lib/lita-jira.rb
@@ -4,7 +4,7 @@ Lita.load_locales Dir[File.expand_path(
   File.join('..', '..', 'locales', '*.yml'), __FILE__
 )]
 
-require 'jira'
+require 'jira-ruby'
 
 require 'jirahelper/issue'
 require 'jirahelper/misc'

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -153,8 +153,7 @@ module Lita
         begin
           issue.save!(fields: { config.points_field.to_sym => points.to_i })
         rescue
-          response.reply(t('error.unable_to_point'))
-          return
+          return response.reply(t('error.unable_to_point'))
         end
         response.reply(t('point.added', issue: issue.key, points: points))
       end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -3,6 +3,7 @@ module Lita
   # Because we can.
   module Handlers
     # Main handler
+    # rubocop:disable Metrics/ClassLength
     class Jira < Handler
       namespace 'Jira'
 
@@ -114,20 +115,23 @@ module Lita
       end
 
       def ambient(response)
-        return if invalid_ambient(response)
+        return if invalid_ambient?(response)
         issue = fetch_issue(response.match_data['issue'], false)
         response.reply(format_issue(issue)) if issue
       end
 
       private
 
-      def invalid_ambient(response)
-        # rubocop:disable Metrics/LineLength
-        response.message.command? || !config.ambient || config.ignore.include?(response.user.name) || config.ignore.include?(response.user.id) || (config.rooms && !config.rooms.include?(response.message.source.room))
-        # rubocop:enable Metrics/LineLength
+      def invalid_ambient?(response)
+        response.message.command? || !config.ambient || ignored?(response.user) || (config.rooms && !config.rooms.include?(response.message.source.room))
+      end
+
+      def ignored?(user)
+        config.ignore.include?(user.id) || config.ignore.include?(user.mention_name) || config.ignore.include?(user.name)
       end
       # rubocop:enable Metrics/AbcSize
     end
+    # rubocop:enable Metrics/ClassLength
     Lita.register_handler(Jira)
   end
 end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -67,6 +67,15 @@ module Lita
         }
       )
 
+      route(
+        /^jira\spoint\s#{ISSUE_PATTERN}\sas\s\d{1,2}$/,
+        :point,
+        command: true,
+        help: {
+          t('help.comment.syntax') => t('help.comment.desc')
+        }
+      )
+
       # Detect ambient JIRA issues in non-command messages
       route AMBIENT_PATTERN, :ambient, command: false
 
@@ -88,6 +97,13 @@ module Lita
         comment = issue.comments.build
         comment.save!(body: response.match_data['comment'])
         response.reply(t('comment.added', issue: issue.key))
+      end
+
+      def point(response)
+        raise "!"
+        issue = fetch_issue(response.match_data['issue'])
+        return response.reply(t('error.request')) unless issue
+        #response.reply(t('comment.added', issue: issue.key))
       end
 
       def todo(response)

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -15,6 +15,7 @@ module Lita
       config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :ignore, required: false, type: Array, default: []
       config :rooms, required: false, type: Array
+      config :use_ssl, required: false, types: [TrueClass, FalseClass], default: true
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -12,6 +12,8 @@ module Lita
       config :context, required: false, type: String, default: ''
       config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :format, required: false, type: String, default: 'verbose'
+      config :ignore, required: false, type: Array, default: []
+      config :rooms, required: false, type: Array
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc
@@ -112,6 +114,8 @@ module Lita
       end
 
       def ambient(response)
+        return if config.ignore.include?(response.user.name)
+        return if config.rooms && !config.rooms.include?(response.message.source.room)
         if config.ambient && !response.message.command?
           issue = fetch_issue(response.match_data['issue'], expected=false)
           response.reply(format_issue(issue)) if issue

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -109,9 +109,9 @@ module Lita
           response.reply(t('error.request'))
           return
         end
-
+        # rubocop:disable Style/ZeroLengthPredicate
         return response.reply(t('myissues.empty')) unless issues.size > 0
-
+        # rubocop:enable Style/ZeroLengthPredicate
         response.reply(format_issues(issues))
       end
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -122,7 +122,9 @@ module Lita
       private
 
       def invalid_ambient(response)
-        response.message.command? || !config.ambient || config.ignore.include?(response.user.name) || (config.rooms && !config.rooms.include?(response.message.source.room))
+        # rubocop:disable Metrics/LineLength
+        response.message.command? || !config.ambient || config.ignore.include?(response.user.name) || config.ignore.include?(response.user.id) || (config.rooms && !config.rooms.include?(response.message.source.room))
+        # rubocop:enable Metrics/LineLength
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -67,7 +67,7 @@ module Lita
       )
 
       # Detect ambient JIRA issues in non-command messages
-      route ISSUE_PATTERN, :ambient, command: false
+      route AMBIENT_PATTERN, :ambient, command: false
 
       def summary(response)
         issue = fetch_issue(response.match_data['issue'])

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -10,8 +10,8 @@ module Lita
       config :password, required: true, type: String
       config :site, required: true, type: String
       config :context, required: false, type: String, default: ''
-      config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :format, required: false, type: String, default: 'verbose'
+      config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :ignore, required: false, type: Array, default: []
       config :rooms, required: false, type: Array
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -114,13 +114,15 @@ module Lita
       end
 
       def ambient(response)
-        return if config.ignore.include?(response.user.name)
-        return if config.rooms && !config.rooms.include?(response.message.source.room)
-        return if response.message.command?
-        return unless config.ambient
-
+        return if invalid_ambient(response)
         issue = fetch_issue(response.match_data['issue'], false)
         response.reply(format_issue(issue)) if issue
+      end
+
+      private
+
+      def invalid_ambient(response)
+        response.message.command? || !config.ambient || config.ignore.include?(response.user.name) || (config.rooms && !config.rooms.include?(response.message.source.room))
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -6,11 +6,12 @@ module Lita
     class Jira < Handler
       namespace 'Jira'
 
-      config :username, required: true
-      config :password, required: true
-      config :site, required: true
-      config :context, required: true
-      config :ambient, types: [TrueClass, FalseClass], default: false
+      config :username, required: true, type: String
+      config :password, required: true, type: String
+      config :site, required: true, type: String
+      config :context, required: false, type: String, default: ''
+      config :ambient, required: false, types: [TrueClass, FalseClass], default: false
+      config :format, required: false, type: String, default: 'verbose'
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc
@@ -113,7 +114,7 @@ module Lita
       def ambient(response)
         if config.ambient && !response.message.command?
           issue = fetch_issue(response.match_data['issue'], expected=false)
-          response.reply(t('issue.summary', key: issue.key, summary: issue.summary)) if issue
+          response.reply(format_issue(issue)) if issue
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -73,7 +73,7 @@ module Lita
         :point,
         command: true,
         help: {
-          t('help.points.syntax') => t('help.points.desc')
+          t('help.point.syntax') => t('help.point.desc')
         }
       )
 
@@ -113,9 +113,7 @@ module Lita
         return response.reply(t('error.field_undefined')) if config.points_field.blank?
         issue = fetch_issue(response.match_data['issue'])
         return response.reply(t('error.request')) unless issue
-        points = response.match_data['points']
-        issue.save(fields: { config.points_field.to_sym => points.to_i })
-        response.reply(t('points.added', issue: issue.key, points: points))
+        set_points_on_issue(issue, response)
       end
 
       def myissues(response)
@@ -148,6 +146,17 @@ module Lita
 
       def ignored?(user)
         config.ignore.include?(user.id) || config.ignore.include?(user.mention_name) || config.ignore.include?(user.name)
+      end
+
+      def set_points_on_issue(issue, response)
+        points = response.match_data['points']
+        begin
+          issue.save!(fields: { config.points_field.to_sym => points.to_i })
+        rescue
+          response.reply(t('error.unable_to_point'))
+          return
+        end
+        response.reply(t('point.added', issue: issue.key, points: points))
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -105,7 +105,7 @@ module Lita
         issue = fetch_issue(response.match_data['issue'])
         return response.reply(t('error.request')) unless issue
         points = response.match_data['points']
-        issue.save(fields: Hash[config.points_field => points.to_i ])
+        issue.save(fields: {config.points_field.to_sym => points.to_i})
         response.reply(t('points.added', issue: issue.key, points: points))
       end
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -101,11 +101,11 @@ module Lita
       end
 
       def point(response)
-        return response.reply(t('error.field_undefined')) unless config.points_field
+        return response.reply(t('error.field_undefined')) if config.points_field.blank?
         issue = fetch_issue(response.match_data['issue'])
         return response.reply(t('error.request')) unless issue
         points = response.match_data['points']
-        issue.save(fields: {config.points_field.to_sym => points.to_i})
+        issue.save(fields: { config.points_field.to_sym => points.to_i })
         response.reply(t('points.added', issue: issue.key, points: points))
       end
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -100,15 +100,6 @@ module Lita
         response.reply(t('comment.added', issue: issue.key))
       end
 
-      def point(response)
-        return response.reply(t('error.field_undefined')) if config.points_field.blank?
-        issue = fetch_issue(response.match_data['issue'])
-        return response.reply(t('error.request')) unless issue
-        points = response.match_data['points']
-        issue.save(fields: { config.points_field.to_sym => points.to_i })
-        response.reply(t('points.added', issue: issue.key, points: points))
-      end
-
       def todo(response)
         issue = create_issue(response.match_data['project'],
                              response.match_data['subject'],
@@ -118,6 +109,15 @@ module Lita
       end
 
       # rubocop:disable Metrics/AbcSize
+      def point(response)
+        return response.reply(t('error.field_undefined')) if config.points_field.blank?
+        issue = fetch_issue(response.match_data['issue'])
+        return response.reply(t('error.request')) unless issue
+        points = response.match_data['points']
+        issue.save(fields: { config.points_field.to_sym => points.to_i })
+        response.reply(t('points.added', issue: issue.key, points: points))
+      end
+
       def myissues(response)
         return response.reply(t('error.not_identified')) unless user_stored?(response.user)
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -16,6 +16,7 @@ module Lita
       config :ignore, required: false, type: Array, default: []
       config :rooms, required: false, type: Array
       config :use_ssl, required: false, types: [TrueClass, FalseClass], default: true
+      config :points_field, required: false, type: String
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc
@@ -100,10 +101,11 @@ module Lita
       end
 
       def point(response)
+        return response.reply(t('error.field_undefined')) unless config.points_field
         issue = fetch_issue(response.match_data['issue'])
         return response.reply(t('error.request')) unless issue
         points = response.match_data['points']
-        issue.save(fields: { customfield_10004: points.to_i }) # Story points is a custom field with id 10004
+        issue.save(fields: Hash[config.points_field => points.to_i ])
         response.reply(t('points.added', issue: issue.key, points: points))
       end
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -89,15 +89,23 @@ module Lita
         response.reply(t('issue.created', key: issue.key))
       end
 
+      # rubocop:disable Metrics/AbcSize
       def myissues(response)
         return response.reply(t('error.not_identified')) unless user_stored?(response.user)
 
-        myissues_jql = "assignee = '#{get_email(response.user)}' AND status not in (Closed)"
-        issues = fetch_issues(myissues_jql)
+        begin
+          issues = fetch_issues("assignee = '#{get_email(response.user)}' AND status not in (Closed)")
+        rescue
+          log.error('JIRA HTTPError')
+          response.reply(t('error.request'))
+          return
+        end
+
         return response.reply(t('myissues.empty')) unless issues.size > 0
 
         response.reply(format_issues(issues))
       end
+      # rubocop:enable Metrics/AbcSize
     end
 
     Lita.register_handler(Jira)

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -109,9 +109,9 @@ module Lita
           response.reply(t('error.request'))
           return
         end
-        # rubocop:disable Style/ZeroLengthPredicate
-        return response.reply(t('myissues.empty')) unless issues.size > 0
-        # rubocop:enable Style/ZeroLengthPredicate
+
+        return response.reply(t('myissues.empty')) if issues.empty?
+
         response.reply(format_issues(issues))
       end
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -68,11 +68,11 @@ module Lita
       )
 
       route(
-        /^jira\spoint\s#{ISSUE_PATTERN}\sas\s\d{1,2}$/,
+        /^jira\spoint\s#{ISSUE_PATTERN}\sas\s#{POINTS_PATTERN}$/,
         :point,
         command: true,
         help: {
-          t('help.comment.syntax') => t('help.comment.desc')
+          t('help.points.syntax') => t('help.points.desc')
         }
       )
 
@@ -100,10 +100,11 @@ module Lita
       end
 
       def point(response)
-        raise "!"
         issue = fetch_issue(response.match_data['issue'])
         return response.reply(t('error.request')) unless issue
-        #response.reply(t('comment.added', issue: issue.key))
+        points = response.match_data['points']
+        issue.save(fields: { customfield_10004: points.to_i }) # Story points is a custom field with id 10004
+        response.reply(t('points.added', issue: issue.key, points: points))
       end
 
       def todo(response)

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -116,10 +116,11 @@ module Lita
       def ambient(response)
         return if config.ignore.include?(response.user.name)
         return if config.rooms && !config.rooms.include?(response.message.source.room)
-        if config.ambient && !response.message.command?
-          issue = fetch_issue(response.match_data['issue'], expected=false)
-          response.reply(format_issue(issue)) if issue
-        end
+        return if response.message.command?
+        return unless config.ambient
+
+        issue = fetch_issue(response.match_data['issue'], false)
+        response.reply(format_issue(issue)) if issue
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.metadata      = { 'lita_plugin_type' => 'handler' }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
-  spec.version       = '0.6.0'
+  spec.version       = '0.7.0'
   spec.authors       = ['Eric Sigler', 'Matt Critchlow']
   spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com']
   spec.description   = 'A JIRA plugin for Lita.'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
-  spec.version       = '0.8.0'
+  spec.version       = '0.8.1'
   spec.authors       = ['Eric Sigler', 'Matt Critchlow', 'Tristan Chong', 'Lee Briggs']
   spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com', 'ong@tristaneuan.ch', 'lee@brig.gs']
   spec.description   = 'A JIRA plugin for Lita.'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
-  spec.version       = '0.7.2'
-  spec.authors       = ['Eric Sigler', 'Matt Critchlow']
-  spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com']
+  spec.version       = '0.8.0'
+  spec.authors       = ['Eric Sigler', 'Matt Critchlow', 'Tristan Chong', 'Lee Briggs']
+  spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com', 'ong@tristaneuan.ch', 'lee@brig.gs']
   spec.description   = 'A JIRA plugin for Lita.'
   spec.summary       = spec.description
   spec.homepage      = 'https://github.com/esigler/lita-jira'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
-  spec.version       = '0.5.0'
+  spec.version       = '0.6.0'
   spec.authors       = ['Eric Sigler']
   spec.email         = ['me@esigler.com']
   spec.description   = 'A JIRA plugin for Lita.'
@@ -15,12 +15,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
-  spec.add_runtime_dependency 'jira-ruby', '>= 0.1.8'
+  spec.add_runtime_dependency 'jira-ruby'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '>= 3.0.0'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
-  spec.version       = '0.7.1'
+  spec.version       = '0.7.2'
   spec.authors       = ['Eric Sigler', 'Matt Critchlow']
   spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com']
   spec.description   = 'A JIRA plugin for Lita.'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
-  spec.version       = '0.7.0'
+  spec.version       = '0.7.1'
   spec.authors       = ['Eric Sigler', 'Matt Critchlow']
   spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com']
   spec.description   = 'A JIRA plugin for Lita.'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
   spec.add_runtime_dependency 'jira-ruby'
+  spec.add_runtime_dependency 'activesupport', ['>= 4.0', '< 5.0']
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
@@ -23,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'jira'
 end

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'jira'
 end

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
   spec.add_runtime_dependency 'jira-ruby'
-  spec.add_runtime_dependency 'activesupport', ['>= 4.0', '< 5.0']
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
   spec.version       = '0.6.0'
-  spec.authors       = ['Eric Sigler']
-  spec.email         = ['me@esigler.com']
+  spec.authors       = ['Eric Sigler', 'Matt Critchlow']
+  spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com']
   spec.description   = 'A JIRA plugin for Lita.'
-  spec.summary       = 'A JIRA plugin for Lita.'
+  spec.summary       = spec.description
   spec.homepage      = 'https://github.com/esigler/lita-jira'
   spec.license       = 'MIT'
   spec.metadata      = { 'lita_plugin_type' => 'handler' }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -7,6 +7,7 @@ en:
           not_identified: You do not have an email address on record
           request: Error fetching JIRA issue
           field_undefined: You must define `points_field` in your lita_config
+          unable_to_point: Cannot set points on issue
         help:
           identify:
             syntax: jira identify <email address>
@@ -22,7 +23,7 @@ en:
             desc: Adds <comment text> to <issue>
           point:
             syntax: jira point <issue> as <points>
-            desc: Adds <points> Story Points to <issue>
+            desc: Adds <points> points to <issue>
           details:
             syntax: jira details <issue>
             desc: Shows detailed information for <issue>
@@ -46,7 +47,7 @@ en:
           summary: "%{key}: %{summary}"
         comment:
           added: "Comment added to %{issue}"
-        points:
+        point:
           added: "Added a point estimation of %{points} to %{issue}"
         myissues:
           empty: "You do not have any assigned issues. Great job!"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,7 +6,7 @@ en:
           already_identified: "You are already identified as %{email}"
           not_identified: You do not have an email address on record
           request: Error fetching JIRA issue
-          points: Point values must be a whole number
+          field_undefined: You must define `points_field` in your lita_config
         help:
           identify:
             syntax: jira identify <email address>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,7 @@ en:
           already_identified: "You are already identified as %{email}"
           not_identified: You do not have an email address on record
           request: Error fetching JIRA issue
+          points: Point values must be a whole number
         help:
           identify:
             syntax: jira identify <email address>
@@ -19,6 +20,9 @@ en:
           comment:
             syntax: jira comment on <issue> <comment text>
             desc: Adds <comment text> to <issue>
+          point:
+            syntax: jira point <issue> as <points>
+            desc: Adds <points> Story Points to <issue>
           details:
             syntax: jira details <issue>
             desc: Shows detailed information for <issue>
@@ -42,6 +46,8 @@ en:
           summary: "%{key}: %{summary}"
         comment:
           added: "Comment added to %{issue}"
+        points:
+          added: "Added a point estimation of %{points} to %{issue}"
         myissues:
           empty: "You do not have any assigned issues. Great job!"
           info: "Here are issues currently assigned to you:"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,6 +28,9 @@ en:
           todo:
             syntax: todo <project> "<subject>" ["<summary>"]
             desc: Creates an issue in <project> with <subject> and optionally <summary>
+          myissues:
+            syntax: jira myissues
+            desc: If identified, will display a list of issues currently assigned to you
         identify:
           stored: "You have been identified as %{email} to JIRA"
           deleted: You have been de-identified from JIRA
@@ -38,3 +41,6 @@ en:
           summary: "%{key}: %{summary}"
         comment:
           added: "Comment added to %{issue}"
+        myissues:
+          empty: "You do not have any assigned issues. Great job!"
+          info: "Here are issues currently assigned to you:"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -37,7 +37,8 @@ en:
           email: "You are identified with JIRA as %{email}"
         issue:
           created: "Issue %{key} created"
-          details: "%{key}: %{summary}, assigned to: %{assigned}, priority: %{priority}, status: %{status}"
+          details: "[%{key}] %{summary}\nStatus: %{status}, assigned to: %{assigned}, fixVersion: %{fixVersion}, priority: %{priority}\n%{url}"
+          oneline: "%{url} - %{status}, %{assigned} - %{summary}"
           summary: "%{key}: %{summary}"
         comment:
           added: "Comment added to %{issue}"

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -207,6 +207,12 @@ describe Lita::Handlers::Jira, lita_handler: true do
       expect(replies.last).to eq('Issue XYZ-987 created')
     end
 
+    it 'creates a new issue if the project is valid and there is a summary' do
+      grab_request(valid_client)
+      send_command('todo XYZ "Some subject text" "Summary text"')
+      expect(replies.last).to eq('Issue XYZ-987 created')
+    end
+
     it 'warns the user when the project is not valid' do
       grab_request(failed_find_project)
       send_command('todo ABC "Some summary text"')

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -180,8 +180,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
   end
 
   describe '#ambient' do
-    it 'does not show details for a detected issue by default' do
-    end
+    it 'does not show details for a detected issue by default'
 
     context 'when enabled in config' do
       before(:each) do
@@ -191,11 +190,18 @@ describe Lita::Handlers::Jira, lita_handler: true do
 
       it 'shows details for a detected issue in a message' do
         send_message('foo XYZ-987 bar')
-        expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+        send_message('foo XYZ-987?')
+        expect(replies.size).to eq(2)
       end
 
       it 'does not show details for a detected issue in a command' do
         send_command('foo XYZ-987 bar')
+        expect(replies.size).to eq(0)
+      end
+
+      it 'does not show details for a issue in a URL-ish context' do
+        send_message('http://www.example.com/XYZ-987.html')
+        send_message('http://www.example.com/someother-XYZ-987.html')
         expect(replies.size).to eq(0)
       end
 

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -284,10 +284,10 @@ describe Lita::Handlers::Jira, lita_handler: true do
         grab_request(valid_client)
         send_command('jira myissues')
         expect(replies[-3..-1]).to eq([
-          'Here are issues currently assigned to you:',
-          "[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987",
-          "[XYZ-988] Some summary text 2\nStatus: In Progress 2, assigned to: A Person 2, fixVersion: none, priority: P1\nhttp://jira.local/browse/XYZ-988"
-        ])
+                                        'Here are issues currently assigned to you:',
+                                        "[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987",
+                                        "[XYZ-988] Some summary text 2\nStatus: In Progress 2, assigned to: A Person 2, fixVersion: none, priority: P1\nhttp://jira.local/browse/XYZ-988"
+                                      ])
       end
 
       it 'shows an error when the search fails' do

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -13,6 +13,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
                     fixVersions: [{ 'name' => 'Sprint 2' }],
                     key: 'XYZ-987')
     allow(result).to receive('save') { true }
+    allow(result).to receive('save!') { true }
     allow(result).to receive('fetch') { true }
     result
   end
@@ -172,7 +173,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
     end
 
     it 'updates the issue with a story point value' do
-      expect(saved_issue).to receive(:save).with(fields: { some_custom_points_field: 5 })
+      expect(saved_issue).to receive(:save!).with(fields: { some_custom_points_field: 5 })
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Added a point estimation of 5 to XYZ-987')
@@ -189,6 +190,13 @@ describe Lita::Handlers::Jira, lita_handler: true do
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('You must define `points_field` in your lita_config')
+    end
+
+    it 'warns the user when settings points fails' do
+      allow(saved_issue).to receive(:save!).and_throw(JIRA::HTTPError)
+      grab_request(valid_client)
+      send_command('jira point XYZ-987 as 5')
+      expect(replies.last).to eq('Cannot set points on issue')
     end
   end
 

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -10,7 +10,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
                     assignee: double(displayName: 'A Person'),
                     priority: double(name: 'P0'),
                     status: double(name: 'In Progress'),
-                    fixVersions: [{'name' => 'Sprint 2'}],
+                    fixVersions: [{ 'name' => 'Sprint 2' }],
                     key: 'XYZ-987')
     allow(result).to receive('save') { true }
     allow(result).to receive('fetch') { true }
@@ -34,7 +34,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
                      assignee: double(displayName: 'A Person'),
                      priority: double(name: 'P0'),
                      status: double(name: 'In Progress'),
-                     fixVersions: [{'name' => 'Sprint 2'}],
+                     fixVersions: [{ 'name' => 'Sprint 2' }],
                      key: 'XYZ-987'),
               double(summary: 'Some summary text 2',
                      assignee: double(displayName: 'A Person 2'),
@@ -179,7 +179,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
     end
   end
 
-  describe "#ambient" do
+  describe '#ambient' do
     it 'does not show details for a detected issue by default' do
     end
 
@@ -239,7 +239,6 @@ describe Lita::Handlers::Jira, lita_handler: true do
         end
       end
     end
-
   end
 
   describe '#myissues' do

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -96,6 +96,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
     is_expected.to route_command('jira ABC-123').to(:summary)
     is_expected.to route_command('jira details ABC-123').to(:details)
     is_expected.to route_command('jira comment on ABC-123 "You just need a cat"').to(:comment)
+    is_expected.to route_command('jira point ABC-123 as 2').to(:point)
     is_expected.to route_command('todo ABC "summary text"').to(:todo)
     is_expected.to route_command('todo ABC "summary text" "subject text"').to(:todo)
     is_expected.to route_command('jira myissues').to(:myissues)
@@ -161,6 +162,20 @@ describe Lita::Handlers::Jira, lita_handler: true do
     it 'warns the user when the issue is not valid' do
       grab_request(failed_find_issue)
       send_command('jira comment on XYZ-987 "Testing"')
+      expect(replies.last).to eq('Error fetching JIRA issue')
+    end
+  end
+
+  describe '#point' do
+    it 'updates the issue with a story point value' do
+      grab_request(valid_client)
+      send_command('jira point XYZ-987 as 5')
+      expect(replies.last).to eq('Added a point estimation of 5 to XYZ-987')
+    end
+
+    it 'warns the user when the issue is not valid' do
+      grab_request(failed_find_issue)
+      send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Error fetching JIRA issue')
     end
   end

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -201,10 +201,11 @@ describe Lita::Handlers::Jira, lita_handler: true do
 
       context 'and an ignore list is defined' do
         before(:each) do
-          @user1 = Lita::User.create('U1', name: 'User1')
-          @user2 = Lita::User.create('U2', name: 'User2')
-          @user3 = Lita::User.create('U3', name: 'User3')
-          registry.config.handlers.jira.ignore = %w(User2 U3)
+          @user1 = Lita::User.create('U1', name: 'User 1', mention_name: 'user1')
+          @user2 = Lita::User.create('U2', name: 'User 2', mention_name: 'user2')
+          @user3 = Lita::User.create('U3', name: 'User 3', mention_name: 'user3')
+          @user4 = Lita::User.create('U4', name: 'User 4', mention_name: 'user4')
+          registry.config.handlers.jira.ignore = ['User 2', 'U3', 'user4']
         end
 
         it 'shows details for a detected issue sent by a user absent from the list' do
@@ -219,6 +220,11 @@ describe Lita::Handlers::Jira, lita_handler: true do
 
         it 'does not show details for a detected issue sent by a user whose ID is on the list' do
           send_message('foo XYZ-987 bar', as: @user3)
+          expect(replies.size).to eq(0)
+        end
+
+        it 'does not show details for a detected issue sent by a user whose mention name is on the list' do
+          send_message('foo XYZ-987 bar', as: @user4)
           expect(replies.size).to eq(0)
         end
       end

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -169,7 +169,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
   describe '#point' do
     it 'updates the issue with a story point value' do
       registry.config.handlers.jira.points_field = 'customfield_10004'
-      expect(saved_issue).to receive(:save).with(fields: { 'customfield_10004' => 5 })
+      expect(saved_issue).to receive(:save).with(fields: { customfield_10004: 5 })
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Added a point estimation of 5 to XYZ-987')

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -167,23 +167,25 @@ describe Lita::Handlers::Jira, lita_handler: true do
   end
 
   describe '#point' do
+    before(:each) do
+      registry.config.handlers.jira.points_field = 'some_custom_points_field'
+    end
+
     it 'updates the issue with a story point value' do
-      registry.config.handlers.jira.points_field = 'customfield_10004'
-      expect(saved_issue).to receive(:save).with(fields: { customfield_10004: 5 })
+      expect(saved_issue).to receive(:save).with(fields: { some_custom_points_field: 5 })
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Added a point estimation of 5 to XYZ-987')
     end
 
     it 'warns the user when the issue is not valid' do
-      registry.config.handlers.jira.points_field = 'customfield_10004'
       grab_request(failed_find_issue)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Error fetching JIRA issue')
     end
 
     it 'warns the user when the config points_field is not defined' do
-      registry.config.handlers.jira.points_field = nil
+      registry.config.handlers.jira.points_field = ''
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('You must define `points_field` in your lita_config')

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -169,7 +169,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
   describe '#point' do
     it 'updates the issue with a story point value' do
       registry.config.handlers.jira.points_field = 'customfield_10004'
-      expect(valid_client).to receive(:save).with({fields: { customfield_10004: 5 }})
+      expect(saved_issue).to receive(:save).with(fields: { 'customfield_10004' => 5 })
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Added a point estimation of 5 to XYZ-987')

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -128,6 +128,14 @@ describe Lita::Handlers::Jira, lita_handler: true do
       expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: unassigned, fixVersion: none, priority: none\nhttp://jira.local/browse/XYZ-987")
     end
 
+    it 'displays the correct URL when config.context is set' do
+      registry.config.handlers.jira.context = '/myjira'
+      grab_request(valid_client)
+      send_command('jira details XYZ-987')
+      expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/myjira/browse/XYZ-987")
+      registry.config.handlers.jira.context = ''
+    end
+
     it 'warns the user when the issue is not valid' do
       grab_request(failed_find_issue)
       send_command('jira details XYZ-987')
@@ -169,6 +177,69 @@ describe Lita::Handlers::Jira, lita_handler: true do
       send_command('todo ABC "Some summary text"')
       expect(replies.last).to eq('Error fetching JIRA issue')
     end
+  end
+
+  describe "#ambient" do
+    it 'does not show details for a detected issue by default' do
+    end
+
+    context 'when enabled in config' do
+      before(:each) do
+        registry.config.handlers.jira.ambient = true
+        grab_request(valid_client)
+      end
+
+      it 'shows details for a detected issue in a message' do
+        send_message('foo XYZ-987 bar')
+        expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+      end
+
+      it 'does not show details for a detected issue in a command' do
+        send_command('foo XYZ-987 bar')
+        expect(replies.size).to eq(0)
+      end
+
+      context 'and an ignore list is defined' do
+        before(:each) do
+          @user1 = Lita::User.create(1, name: 'User1')
+          @user2 = Lita::User.create(2, name: 'User2')
+          registry.config.handlers.jira.ignore = ['User2']
+        end
+
+        it 'shows details for a detected issue sent by a user absent from the list' do
+          send_message('foo XYZ-987 bar', as: @user1)
+          expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+        end
+
+        it 'does not show details for a detected issue sent by a user on the list' do
+          send_message('foo XYZ-987 bar', as: @user2)
+          expect(replies.size).to eq(0)
+        end
+      end
+
+      context 'and a room list is defined' do
+        def send_room_message(body, room)
+          robot.receive(Lita::Message.new(robot, body, Lita::Source.new(user: user, room: room)))
+        end
+
+        before(:each) do
+          @room1 = 'Room1'
+          @room2 = 'Room2'
+          registry.config.handlers.jira.rooms = [@room1]
+        end
+
+        it 'shows details for a detected issue sent in a room on the list' do
+          send_room_message('foo XYZ-987 bar', @room1)
+          expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+        end
+
+        it 'does not show details for a detected issue sent in a room absent from the list' do
+          send_room_message('foo XYZ-987 bar', @room2)
+          expect(replies.size).to eq(0)
+        end
+      end
+    end
+
   end
 
   describe '#myissues' do

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -168,15 +168,25 @@ describe Lita::Handlers::Jira, lita_handler: true do
 
   describe '#point' do
     it 'updates the issue with a story point value' do
+      registry.config.handlers.jira.points_field = 'customfield_10004'
+      expect(valid_client).to receive(:save).with({fields: { customfield_10004: 5 }})
       grab_request(valid_client)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Added a point estimation of 5 to XYZ-987')
     end
 
     it 'warns the user when the issue is not valid' do
+      registry.config.handlers.jira.points_field = 'customfield_10004'
       grab_request(failed_find_issue)
       send_command('jira point XYZ-987 as 5')
       expect(replies.last).to eq('Error fetching JIRA issue')
+    end
+
+    it 'warns the user when the config points_field is not defined' do
+      registry.config.handlers.jira.points_field = nil
+      grab_request(valid_client)
+      send_command('jira point XYZ-987 as 5')
+      expect(replies.last).to eq('You must define `points_field` in your lita_config')
     end
   end
 

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -189,9 +189,10 @@ describe Lita::Handlers::Jira, lita_handler: true do
       end
 
       it 'shows details for a detected issue in a message' do
+        send_message('XYZ-987')
         send_message('foo XYZ-987 bar')
         send_message('foo XYZ-987?')
-        expect(replies.size).to eq(2)
+        expect(replies.size).to eq(3)
       end
 
       it 'does not show details for a detected issue in a command' do
@@ -200,8 +201,10 @@ describe Lita::Handlers::Jira, lita_handler: true do
       end
 
       it 'does not show details for a issue in a URL-ish context' do
+        send_message('http://www.example.com/XYZ-987')
         send_message('http://www.example.com/XYZ-987.html')
         send_message('http://www.example.com/someother-XYZ-987.html')
+        send_message('TIL http://ruby-doc.org/core-2.3.0/Enumerable.html#method-i-each_slice')
         expect(replies.size).to eq(0)
       end
 

--- a/spec/lita/handlers/regex_spec.rb
+++ b/spec/lita/handlers/regex_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe JiraHelper::Regex do
+	
+	PROJECT_PATTERN = JiraHelper::Regex::PROJECT_PATTERN
+	SUBJECT_PATTERN = JiraHelper::Regex::SUBJECT_PATTERN
+	SUMMARY_PATTERN = JiraHelper::Regex::SUMMARY_PATTERN
+
+	#
+	# route(
+	#        /^todo\s#{PROJECT_PATTERN}\s#{SUBJECT_PATTERN}(\s#{SUMMARY_PATTERN})?$/,
+	#
+	let(:regex) {Regexp.new(/^todo\s#{PROJECT_PATTERN}\s#{SUBJECT_PATTERN}(\s#{SUMMARY_PATTERN})?$/)}
+	
+	it 'double qoutes around subject and summary' do
+		subject = "Any subject"
+		summary = "Any summary"
+		project = 'PRJ'
+		message = %(todo #{project} "#{subject}" "#{summary}")
+		match = message.match(regex)
+		expect(match['project']).to eq(project)
+		expect(match['summary']).to eq(summary)
+		expect(match['subject']).to eq(subject)
+	end
+
+end

--- a/spec/lita/handlers/regex_spec.rb
+++ b/spec/lita/handlers/regex_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe JiraHelper::Regex do
+describe JiraHelper::Regex, lita_handler: true do
 	
 	PROJECT_PATTERN = JiraHelper::Regex::PROJECT_PATTERN
 	SUBJECT_PATTERN = JiraHelper::Regex::SUBJECT_PATTERN

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
Found that final regex to match the message while creating issue was:

```
(?-mix:^todo\s(?-mix:(?<project>[a-zA-Z0-9]{1,10}))\s(\"(?<subject>.+)\")(\s(?-mix:\"(?<summary>.+?)\"))?$)
```

Giving the message: todo PRJ "Test" "Test" everything after the first closing quote was matched as 'subject' match variable.

Fix is more greedy regex, stopping matching after the first closing quotes.