### PR TITLE
Fixing regexes to make 'todo' works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3.0
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
+  - 2.3
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
+  - 2.2.2
 services:
   - redis-server
 sudo: false

--- a/lib/jirahelper/regex.rb
+++ b/lib/jirahelper/regex.rb
@@ -3,8 +3,8 @@ module JiraHelper
   # Regular expressions
   module Regex
     COMMENT_PATTERN = /\"(?<comment>.+)\"/
-    SUBJECT_PATTERN = /\"(?<subject>.+)\"/
-    SUMMARY_PATTERN = /\"(?<summary>.+)\"/
+    SUBJECT_PATTERN = /\"(?<subject>.+?)\"/
+    SUMMARY_PATTERN = /\"(?<summary>.+?)\"/
     PROJECT_PATTERN = /(?<project>[a-zA-Z0-9]{1,10})/
     ISSUE_PATTERN   = /(?<issue>#{PROJECT_PATTERN}-[0-9]{1,5}+)/
     EMAIL_PATTERN   = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i

--- a/lib/lita-jira.rb
+++ b/lib/lita-jira.rb
@@ -4,7 +4,7 @@ Lita.load_locales Dir[File.expand_path(
   File.join('..', '..', 'locales', '*.yml'), __FILE__
 )]
 
-require 'jira'
+require 'jira-ruby'
 
 require 'jirahelper/issue'
 require 'jirahelper/misc'

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
   spec.add_runtime_dependency 'jira-ruby'
+  spec.add_runtime_dependency 'activesupport', ['>= 4.0', '< 5.0']
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
@@ -23,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'jira'
 end

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'jira'
 end

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
   spec.add_runtime_dependency 'jira-ruby'
-  spec.add_runtime_dependency 'activesupport', ['>= 4.0', '< 5.0']
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -207,6 +207,12 @@ describe Lita::Handlers::Jira, lita_handler: true do
       expect(replies.last).to eq('Issue XYZ-987 created')
     end
 
+    it 'creates a new issue if the project is valid and there is a summary' do
+      grab_request(valid_client)
+      send_command('todo XYZ "Some subject text" "Summary text"')
+      expect(replies.last).to eq('Issue XYZ-987 created')
+    end
+
     it 'warns the user when the project is not valid' do
       grab_request(failed_find_project)
       send_command('todo ABC "Some summary text"')

--- a/spec/lita/handlers/regex_spec.rb
+++ b/spec/lita/handlers/regex_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe JiraHelper::Regex do
+	
+	PROJECT_PATTERN = JiraHelper::Regex::PROJECT_PATTERN
+	SUBJECT_PATTERN = JiraHelper::Regex::SUBJECT_PATTERN
+	SUMMARY_PATTERN = JiraHelper::Regex::SUMMARY_PATTERN
+
+	#
+	# route(
+	#        /^todo\s#{PROJECT_PATTERN}\s#{SUBJECT_PATTERN}(\s#{SUMMARY_PATTERN})?$/,
+	#
+	let(:regex) {Regexp.new(/^todo\s#{PROJECT_PATTERN}\s#{SUBJECT_PATTERN}(\s#{SUMMARY_PATTERN})?$/)}
+	
+	it 'double qoutes around subject and summary' do
+		subject = "Any subject"
+		summary = "Any summary"
+		project = 'PRJ'
+		message = %(todo #{project} "#{subject}" "#{summary}")
+		match = message.match(regex)
+		expect(match['project']).to eq(project)
+		expect(match['summary']).to eq(summary)
+		expect(match['subject']).to eq(subject)
+	end
+
+end

--- a/spec/lita/handlers/regex_spec.rb
+++ b/spec/lita/handlers/regex_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe JiraHelper::Regex do
+describe JiraHelper::Regex, lita_handler: true do
 	
 	PROJECT_PATTERN = JiraHelper::Regex::PROJECT_PATTERN
 	SUBJECT_PATTERN = JiraHelper::Regex::SUBJECT_PATTERN


### PR DESCRIPTION
Found that final regex to match the message while creating issue was:

```
(?-mix:^todo\s(?-mix:(?<project>[a-zA-Z0-9]{1,10}))\s(\"(?<subject>.+)\")(\s(?-mix:\"(?<summary>.+?)\"))?$)
````
Giving the message: `todo PRJ "Test" "Test"` everything after the first closing quote was matched as 'subject' match variable.

Fix is more greedy regex, stopping matching after the first closing quotes.